### PR TITLE
QEMU resources disk clone permissions issue fix

### DIFF
--- a/see/context/resources/qemu.py
+++ b/see/context/resources/qemu.py
@@ -92,6 +92,9 @@ VOLUME_DEFAULT_CONFIG = """
   <uuid>{0}</uuid>
   <target>
     <path>{1}</path>
+    <permissions>
+      <mode>0644</mode>
+    </permissions>
     <format type='qcow2'/>
   </target>
 </volume>


### PR DESCRIPTION
Cloned disk gets created with permissions set to 600 and owned by libvirt.

This prevents any other user to access to it for inspection.

