### PR TITLE
Mitigate concurrent image download

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
 
 setup(
     name="python-see",
-    version="1.2.11",
+    version="1.2.12",
     author="F-Secure Corporation",
     author_email="matteo.cafasso@f-secure.com",
     description=("Sandboxed Execution Environment"),


### PR DESCRIPTION
When running see in parallel processes while using the glance_os provider, several processes may download the same image at the same time. This is suboptimal.