### PR TITLE
Optionally refresh possible backing libvirt pool

### DIFF
--- a/see/image_providers/os_glance.py
+++ b/see/image_providers/os_glance.py
@@ -28,7 +28,9 @@ provider_parameters:
     session (dict):      A dictionary with OpenStack Session parameters. Allows
                          authentication to Keystone over TLS.
     libvirt_pool (dict): An optional dictionary with backing libvirt pool
-                         configuration.
+                         configuration, with the following keys:
+        hypervisor (str):   The URL of the hypervisor to connect to.
+        name (str):         The name of the libvirt storage pool.
 """
 
 import os

--- a/see/image_providers/os_glance.py
+++ b/see/image_providers/os_glance.py
@@ -27,8 +27,6 @@ provider_parameters:
                          as needed by OpenStack's Keystone client.
     session (dict):      A dictionary with OpenStack Session parameters. Allows
                          authentication to Keystone over TLS.
-    page_size (int):     The number of records to retrieve at once on glance
-                         listing operations. Default 1.
     libvirt_pool (dict): An optional dictionary with backing libvirt pool
                          configuration, with the following keys:
         hypervisor (str):   The URL of the hypervisor to connect to.
@@ -57,9 +55,6 @@ def verify_checksum(path, checksum):
                 break
             hash_md5.update(chunk)
     return hash_md5.hexdigest() == checksum
-
-
-PAGE_SIZE = 1
 
 
 class GlanceProvider(ImageProvider):
@@ -121,7 +116,6 @@ class GlanceProvider(ImageProvider):
 
     def _find_potentials(self):
         return sorted([image for image in self.glance_client.images.list(
-            page_size=self.configuration.get('page_size', PAGE_SIZE),
             filters={'name': self.name})
                        if image.status != 'active'],
                       key=lambda x: x.updated_at, reverse=True)
@@ -129,7 +123,6 @@ class GlanceProvider(ImageProvider):
     def _retrieve_metadata(self):
         try:
             return sorted([image for image in self.glance_client.images.list(
-                page_size=self.configuration.get('page_size', PAGE_SIZE),
                 filters={'name': self.name, 'status': 'active'})],
                           key=lambda x: x.updated_at, reverse=True)[0]
         except IndexError:
@@ -139,7 +132,6 @@ class GlanceProvider(ImageProvider):
         partfile = '{}.part'.format(target)
         if os.path.exists(partfile):
             for image in sorted([img for img in self.glance_client.images.list(
-                    page_size=self.configuration.get('page_size', PAGE_SIZE),
                     filters={'name': self.name, 'status': 'active'})],
                                 key=lambda x: x.updated_at, reverse=True):
                 newtarget = os.path.join(os.path.dirname(target), image.id)

--- a/see/image_providers/os_glance.py
+++ b/see/image_providers/os_glance.py
@@ -27,6 +27,8 @@ provider_parameters:
                          as needed by OpenStack's Keystone client.
     session (dict):      A dictionary with OpenStack Session parameters. Allows
                          authentication to Keystone over TLS.
+    page_size (int):     The number of records to retrieve at once on glance
+                         listing operations. Default 1.
     libvirt_pool (dict): An optional dictionary with backing libvirt pool
                          configuration, with the following keys:
         hypervisor (str):   The URL of the hypervisor to connect to.
@@ -55,6 +57,9 @@ def verify_checksum(path, checksum):
                 break
             hash_md5.update(chunk)
     return hash_md5.hexdigest() == checksum
+
+
+PAGE_SIZE = 1
 
 
 class GlanceProvider(ImageProvider):
@@ -101,9 +106,10 @@ class GlanceProvider(ImageProvider):
             from keystoneauth1.identity import v3
             from keystoneauth1.session import Session
 
-            self._os_session = Session(auth=v3.Password(**self.configuration['os_auth']),
-                                       verify=self.configuration['session'].get('cacert', False),
-                                       cert=self.configuration['session'].get('cert'))
+            self._os_session = Session(
+                auth=v3.Password(**self.configuration['os_auth']),
+                verify=self.configuration['session'].get('cacert', False),
+                cert=self.configuration['session'].get('cert'))
         return self._os_session
 
     @property
@@ -115,14 +121,16 @@ class GlanceProvider(ImageProvider):
 
     def _find_potentials(self):
         return sorted([image for image in self.glance_client.images.list(
-            page_size=2, filters={'name': self.name})
+            page_size=self.configuration.get('page_size', PAGE_SIZE),
+            filters={'name': self.name})
                        if image.status != 'active'],
                       key=lambda x: x.updated_at, reverse=True)
 
     def _retrieve_metadata(self):
         try:
             return sorted([image for image in self.glance_client.images.list(
-                page_size=2, filters={'name': self.name, 'status': 'active'})],
+                page_size=self.configuration.get('page_size', PAGE_SIZE),
+                filters={'name': self.name, 'status': 'active'})],
                           key=lambda x: x.updated_at, reverse=True)[0]
         except IndexError:
             raise FileNotFoundError(self.name)
@@ -131,8 +139,8 @@ class GlanceProvider(ImageProvider):
         partfile = '{}.part'.format(target)
         if os.path.exists(partfile):
             for image in sorted([img for img in self.glance_client.images.list(
-                    page_size=2, filters={'name': self.name,
-                                          'status': 'active'})],
+                    page_size=self.configuration.get('page_size', PAGE_SIZE),
+                    filters={'name': self.name, 'status': 'active'})],
                                 key=lambda x: x.updated_at, reverse=True):
                 newtarget = os.path.join(os.path.dirname(target), image.id)
                 if os.path.exists(newtarget):

--- a/see/image_providers/os_glance.py
+++ b/see/image_providers/os_glance.py
@@ -112,16 +112,15 @@ class GlanceProvider(ImageProvider):
         return self._glance_client
 
     def _find_potentials(self):
-        return sorted([image for image in self.glance_client.images.list()
-                       if (image.id == self.name or image.name == self.name)
-                       and image.status != 'active'],
+        return sorted([image for image in self.glance_client.images.list(
+            page_size=2, filters={'name': self.name})
+                       if image.status != 'active'],
                       key=lambda x: x.updated_at, reverse=True)
 
     def _retrieve_metadata(self):
         try:
-            return sorted([image for image in self.glance_client.images.list()
-                           if (image.id == self.name or image.name == self.name)
-                           and image.status == 'active'],
+            return sorted([image for image in self.glance_client.images.list(
+                page_size=2, filters={'name': self.name, 'status': 'active'})],
                           key=lambda x: x.updated_at, reverse=True)[0]
         except IndexError:
             raise FileNotFoundError(self.name)
@@ -129,10 +128,9 @@ class GlanceProvider(ImageProvider):
     def _download_image(self, img_metadata, target):
         partfile = '{}.part'.format(target)
         if os.path.exists(partfile):
-            for image in sorted([img for img in self.glance_client.images.list()
-                                 if (img.id == self.name or
-                                     img.name == self.name)
-                                 and img.status == 'active'],
+            for image in sorted([img for img in self.glance_client.images.list(
+                    page_size=2, filters={'name': self.name,
+                                          'status': 'active'})],
                                 key=lambda x: x.updated_at, reverse=True):
                 newtarget = os.path.join(os.path.dirname(target), image.id)
                 if os.path.exists(newtarget):

--- a/see/image_providers/test/os_glance_test.py
+++ b/see/image_providers/test/os_glance_test.py
@@ -86,8 +86,10 @@ class ImageTest(unittest.TestCase):
             _ = resources.provider_image
 
     def test_image_unavailable_target_is_file(self, glance_mock, os_mock, _):
-        glance_mock.images.list.return_value = [self.wrongimage, self.image3]
+        glance_mock.images.list.return_value = []
 
+        os_mock.path.join = os.path.join
+        os_mock.path.dirname = os.path.dirname
         os_mock.path.exists.return_value = True
         os_mock.path.isfile.return_value = True
         resources = Resources('foo', self.config)
@@ -97,9 +99,10 @@ class ImageTest(unittest.TestCase):
     def test_image_unavailable_target_is_dir(self, glance_mock, os_mock, _):
         glance_mock.images.list.return_value = [self.image3]
 
+        os_mock.path.join = os.path.join
+        os_mock.path.dirname = os.path.dirname
         os_mock.path.exists.return_value = True
         os_mock.path.isfile.return_value = False
-        os_mock.path.join = os.path.join
         resources = Resources('foo', self.config)
         expected_image_path = self.config['disk']['image']['provider_configuration']['path'] + '/3'
         assert resources.provider_image == expected_image_path
@@ -115,6 +118,7 @@ class ImageTest(unittest.TestCase):
         hashlib_mock.md5.return_value = md5
 
         os_mock.path.join = os.path.join
+        os_mock.path.dirname = os.path.dirname
         os_mock.path.exists.return_value = False
         os_mock.path.isfile.return_value = False
         os_mock.path.getmtime.return_value = 0
@@ -132,11 +136,14 @@ class ImageTest(unittest.TestCase):
     def test_image_unavailable_target_is_dir_no_cached(self, glance_mock, os_mock, _):
         glance_mock.images.list.return_value = [self.image3]
 
+        os_mock.path.join = os.path.join
+        os_mock.path.dirname = os.path.dirname
         os_mock.path.exists.side_effect = lambda x: {'/foo/bar/1': False,
+                                                     '/foo/bar/1.part': False,
                                                      '/foo/bar/3': False,
+                                                     '/foo/bar/3.part': False,
                                                      '/foo/bar': True}[x]
         os_mock.path.isfile.return_value = False
-        os_mock.path.join = os.path.join
 
         resources = Resources('foo', self.config)
         with self.assertRaises(FileNotFoundError):

--- a/see/image_providers/test/os_glance_test.py
+++ b/see/image_providers/test/os_glance_test.py
@@ -95,7 +95,7 @@ class ImageTest(unittest.TestCase):
         assert resources.provider_image == expected_image_path
 
     def test_image_unavailable_target_is_dir(self, glance_mock, os_mock, _):
-        glance_mock.images.list.return_value = [self.wrongimage, self.image3]
+        glance_mock.images.list.return_value = [self.image3]
 
         os_mock.path.exists.return_value = True
         os_mock.path.isfile.return_value = False
@@ -108,7 +108,7 @@ class ImageTest(unittest.TestCase):
     @mock.patch('%s.open' % builtin_module, new_callable=mock.mock_open)
     @mock.patch('see.image_providers.os_glance.hashlib')
     def test_image_unavailable_target_does_not_exist(self, hashlib_mock, open_mock, temp_mock, glance_mock, os_mock, _):
-        glance_mock.images.list.return_value = [self.wrongimage, self.image2]
+        glance_mock.images.list.return_value = [self.image2]
 
         md5 = mock.MagicMock()
         md5.hexdigest.return_value = '2222'
@@ -130,7 +130,7 @@ class ImageTest(unittest.TestCase):
         os_mock.remove.assert_not_called()
 
     def test_image_unavailable_target_is_dir_no_cached(self, glance_mock, os_mock, _):
-        glance_mock.images.list.return_value = [self.wrongimage, self.image3]
+        glance_mock.images.list.return_value = [self.image3]
 
         os_mock.path.exists.side_effect = lambda x: {'/foo/bar/1': False,
                                                      '/foo/bar/3': False,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
 
 setup(
     name="python-see",
-    version="1.3.0",
+    version="1.3.1",
     author="F-Secure Corporation",
     author_email="matteo.cafasso@f-secure.com",
     description=("Sandboxed Execution Environment"),


### PR DESCRIPTION
If the glance provider drops the images in a libvirt pool, it should refresh that pool after image dowload.