### PR TITLE
Tag image at the proper path

### DIFF
--- a/see/context/resources/qemu.py
+++ b/see/context/resources/qemu.py
@@ -372,7 +372,7 @@ class QEMUResources(resources.Resources):
             network_name = self._network.name()
 
         disk_path = self._retrieve_disk_path()
-        tag_disk(disk_path)
+        tag_disk(self.provider_image)
 
         if self._storage_pool is not None:
             self._storage_pool.refresh()

--- a/see/context/resources/vbox.py
+++ b/see/context/resources/vbox.py
@@ -131,7 +131,7 @@ class VBoxResources(resources.Resources):
     def allocate(self):
         """Initializes libvirt resources."""
         disk_path = self.provider_image
-        tag_disk(disk_path)
+        tag_disk(self.provider_image)
 
         self._hypervisor = libvirt.open(
             self.configuration.get('hypervisor', 'vbox:///session'))

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
 
 setup(
     name="python-see",
-    version="1.3.6",
+    version="1.3.7",
     author="F-Secure Corporation",
     author_email="matteo.cafasso@f-secure.com",
     description=("Sandboxed Execution Environment"),


### PR DESCRIPTION
SEE was tagging the provider image on its COW copy rather than the original golden image.